### PR TITLE
Feat/design item n header

### DIFF
--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -15,8 +15,8 @@ const AppLayout: React.FC<AppLayoutProps> = ({ children }: AppLayoutProps) => (
 
 const Main = styled.main`
   margin: 0 auto;
+  padding: 0 10px;
   max-width: 700px;
-  /* background: skyblue; */
 `;
 
 export default AppLayout;

--- a/src/components/DateRangeText.tsx
+++ b/src/components/DateRangeText.tsx
@@ -25,10 +25,6 @@ const DateRangeText: React.FC<DateRangeTextProps> = ({
 };
 
 const Wrap = styled.p`
-  span {
-    vertical-align: middle;
-    line-height: 1;
-  }
   span + span {
     margin-left: 5px;
   }

--- a/src/components/DateRangeText.tsx
+++ b/src/components/DateRangeText.tsx
@@ -12,7 +12,6 @@ const DateRangeText: React.FC<DateRangeTextProps> = ({
 
   return (
     <Wrap>
-      <span>⏱</span>
       <span>
         {dueDateRange && dateFormat({ targetDate: new Date(startDate) })}
       </span>
@@ -24,10 +23,8 @@ const DateRangeText: React.FC<DateRangeTextProps> = ({
   );
 };
 
-const Wrap = styled.p`
-  span + span {
-    margin-left: 5px;
-  }
+const Wrap = styled.div`
+  margin-left: 5px;
 `;
 
 export default DateRangeText;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 import { SiTodoist } from 'react-icons/si';
-import TodoForm from './TodoForm';
+import TodoForm from 'pages/todo/TodoForm';
 
 const Header: React.FC = () => (
   <Head>
@@ -15,7 +15,6 @@ const Head = styled.header`
   position: sticky;
   top: 0;
   left: 0;
-  margin-bottom: 40px;
   padding: 30px 40px;
   text-align: center;
   border-bottom: 1px solid #eee;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -14,10 +14,9 @@ const Header: React.FC = () => (
 const Head = styled.header`
   position: sticky;
   top: 0;
-  left: 0;
-  padding: 30px 40px;
+  padding: 20px 10px;
   text-align: center;
-  border-bottom: 1px solid #eee;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
   background: #fff;
   z-index: 9999;
   h1 {
@@ -28,9 +27,6 @@ const Head = styled.header`
     color: #0099fd;
     svg {
       margin-right: 10px;
-    }
-    span {
-      line-height: 1;
     }
   }
 `;

--- a/src/pages/todo/TodoContainer.tsx
+++ b/src/pages/todo/TodoContainer.tsx
@@ -85,19 +85,20 @@ const Wrapper = styled.div`
   animation-duration: 10s;
   animation-iteration-count: infinite;
   animation-direction: alternate;
-  border-radius: 50px;
+  border-radius: 10px;
+  margin: 20px 0;
+  padding: 20px;
 `;
 
 const TodoSelectedContainer = styled.div`
   display: flex;
   flex-direction: row-reverse;
+  margin-bottom: 10px;
 `;
 
 const TodoSelectedDiv = styled.div`
   display: flex;
   align-items: center;
-  height: 10%;
-  margin: 30px 30px 0 0;
 `;
 
 const SortButton = styled.img`

--- a/src/pages/todo/TodoForm.tsx
+++ b/src/pages/todo/TodoForm.tsx
@@ -11,8 +11,8 @@ import useRangePickerVisible from 'hooks/useRangePickerVisible';
 import dateFormat from 'utils/date';
 
 import TodoContext from 'store/todo';
-import DatePicker from './DatePicker';
-import DateRangeText from './DateRangeText';
+import DatePicker from 'components/DatePicker';
+import DateRangeText from 'components/DateRangeText';
 
 const TodoForm: FC = () => {
   const {

--- a/src/pages/todo/TodoForm.tsx
+++ b/src/pages/todo/TodoForm.tsx
@@ -8,8 +8,6 @@ import { css } from '@emotion/react';
 import useTodo, { IMPORTANCE_OPTIONS } from 'hooks/useTodo';
 import useRangePickerVisible from 'hooks/useRangePickerVisible';
 
-import dateFormat from 'utils/date';
-
 import TodoContext from 'store/todo';
 import DatePicker from 'components/DatePicker';
 import DateRangeText from 'components/DateRangeText';
@@ -48,23 +46,21 @@ const TodoForm: FC = () => {
 
   return (
     <FormWrap onSubmit={handleSubmit}>
-      <Today>Today is, {dateFormat({ targetDate: new Date() })}</Today>
       <form>
         <FormTop>
-          <InputBox>
-            <input
-              name="taskName"
-              value={taskName}
-              onChange={handleInputChange}
-            />
-            <IconButton
-              type="button"
-              onClick={handleRangePickerVisibleToggle}
-              active={rangePickerOpen}
-            >
-              <FaCalendarAlt />
-            </IconButton>
-          </InputBox>
+          <InputBox
+            name="taskName"
+            value={taskName}
+            onChange={handleInputChange}
+          ></InputBox>
+          <IconButton
+            type="button"
+            onClick={handleRangePickerVisibleToggle}
+            active={rangePickerOpen}
+          >
+            <FaCalendarAlt />
+            {dueDateRange && <DateRangeText dueDateRange={dueDateRange} />}
+          </IconButton>
           <Select>
             <select
               name="importance"
@@ -82,11 +78,8 @@ const TodoForm: FC = () => {
             </select>
             <MdKeyboardArrowDown />
           </Select>
+          <SubmitButton type="submit">추가</SubmitButton>
         </FormTop>
-
-        {dueDateRange && <DateRangeText dueDateRange={dueDateRange} />}
-
-        <Button type="submit">추가</Button>
 
         {rangePickerOpen && (
           <CustomDatePicker
@@ -102,53 +95,40 @@ const TodoForm: FC = () => {
 
 const FormWrap = styled.div`
   display: inline-block;
-  max-width: 500px;
+  max-width: 700px;
   width: 100%;
   form {
     position: relative;
   }
 `;
 
-const Today = styled.p`
-  margin-bottom: 20px;
-  font-size: 17px;
-  color: #aeb9bf;
-`;
-
 const FormTop = styled.div`
+  width: 100%;
   display: flex;
-  & + button {
-    margin-top: 20px;
-  }
-  & + p {
-    margin: 20px 0;
+  & > input {
+    flex: 1;
   }
   & > * + * {
     margin-left: 5px;
   }
   @media screen and (max-width: 420px) {
-    flex-direction: column;
-
+    flex-wrap: wrap;
+    & > input,
+    & > button[type='button'] {
+      width: 100%;
+    }
+    & > button[type='submit'] {
+      margin-left: auto;
+    }
     & > * + * {
-      margin: 5px 0 0 0;
+      margin: 5px 0 0;
     }
   }
 `;
 
-const InputBox = styled.p`
-  display: flex;
-  flex: 1;
+const InputBox = styled.input`
   height: 37px;
   border: 1px solid #dcdcdc;
-  input {
-    flex: 1;
-    padding: 10px;
-    border: none;
-    outline: none;
-  }
-  button {
-    border: none;
-  }
 `;
 
 const CustomDatePicker = styled(DatePicker)`
@@ -209,6 +189,9 @@ const Select = styled.p`
 `;
 
 const IconButton = styled(Button)`
+  display: flex;
+  align-items: center;
+  justify-content: center;
   padding: 10px;
   ${({ active }: { active?: boolean }) =>
     active &&
@@ -216,6 +199,15 @@ const IconButton = styled(Button)`
       color: #0099fd;
       border-color: #0099fd;
     `}
+`;
+
+const SubmitButton = styled(Button)`
+  background-color: #0099fd;
+  color: #fff;
+  border: none;
+  &:hover {
+    color: #fff;
+  }
 `;
 
 export default TodoForm;

--- a/src/pages/todo/TodoItem.tsx
+++ b/src/pages/todo/TodoItem.tsx
@@ -84,7 +84,6 @@ const TodoItem: React.FC<TodoItemProps> = ({
     <TodoItemDiv isComplete={data.status === FINISHED}>
       <TodoItemInfoDiv>
         <TopDiv>
-          {' '}
           {data.importance === '3' ? (
             <Symbol
               color={GREEN}
@@ -124,36 +123,8 @@ const TodoItem: React.FC<TodoItemProps> = ({
             </StatusDiv>
           )}
         </TopDiv>
-      </TodoItemInfoDiv>
-      <TodoItemInfoDiv>
-        {taskNameEditMode ? (
-          <input
-            placeholder="To do what"
-            onKeyPress={(e) => handleEnterPress(e, data.id)}
-            ref={inputEl}
-          />
-        ) : (
-          <div>
-            <span>{data.taskName}</span>
-          </div>
-        )}
-      </TodoItemInfoDiv>
-      <TodoItemInfoDiv>
         <DueDateRangeDiv>
           <DateRangeText dueDateRange={data.dueDateRange} />
-        </DueDateRangeDiv>
-        <div>
-          {taskNameEditMode ? (
-            <ConfirmBtn
-              src={CONFIRM_ICON}
-              onClick={() => handleTaskNameEdit(data.id)}
-            />
-          ) : (
-            <TaskNameEditBtn
-              src={PENCIL_ICON}
-              onClick={() => setTaskNameEditMode((prev) => !prev)}
-            />
-          )}
           {rangePickerOpen ? (
             <CancelBtn
               src={CANCEL_ICON}
@@ -165,8 +136,34 @@ const TodoItem: React.FC<TodoItemProps> = ({
               onClick={handleRangePickerVisibleToggle}
             />
           )}
+        </DueDateRangeDiv>
+      </TodoItemInfoDiv>
+      <TodoItemInfoDiv>
+        <TaskName>
+          {taskNameEditMode ? (
+            <input
+              placeholder="To do what"
+              onKeyPress={(e) => handleEnterPress(e, data.id)}
+              ref={inputEl}
+            />
+          ) : (
+            <TaskNameParagraph>{data.taskName}</TaskNameParagraph>
+          )}
+        </TaskName>
+        <TaskControlDiv>
+          {taskNameEditMode ? (
+            <ConfirmBtn
+              src={CONFIRM_ICON}
+              onClick={() => handleTaskNameEdit(data.id)}
+            />
+          ) : (
+            <TaskNameEditBtn
+              src={PENCIL_ICON}
+              onClick={() => setTaskNameEditMode((prev) => !prev)}
+            />
+          )}
           <TrashBtn src={TRASH_ICON} onClick={() => handleDelete(data.id)} />
-        </div>
+        </TaskControlDiv>
       </TodoItemInfoDiv>
       {rangePickerOpen && (
         <CustomDatePicker
@@ -202,7 +199,13 @@ const TodoItemInfoDiv = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  padding: 10px;
+  margin: 28px 0;
+  &:first-child {
+    margin-top: 0;
+  }
+  &:last-child {
+    margin-bottom: 0;
+  }
 `;
 
 const TopDiv = styled.div`
@@ -210,7 +213,22 @@ const TopDiv = styled.div`
 `;
 
 const DueDateRangeDiv = styled.div`
-  font-size: 8px;
+  display: flex;
+  flex-direction: row;
+  font-size: 11px;
+  align-items: center;
+`;
+
+const TaskName = styled.div`
+  flex: 1;
+`;
+
+const TaskNameParagraph = styled.p`
+  word-break: break-all;
+`;
+
+const TaskControlDiv = styled.div`
+  margin-left: 10px;
 `;
 
 const Button = styled.img`
@@ -223,8 +241,12 @@ const Button = styled.img`
 const TrashBtn = styled(Button)``;
 const ConfirmBtn = styled(Button)``;
 const TaskNameEditBtn = styled(Button)``;
-const CancelBtn = styled(Button)``;
-const DueDateRangeEditBtn = styled(Button)``;
+const CancelBtn = styled(Button)`
+  margin-left: 10px;
+`;
+const DueDateRangeEditBtn = styled(Button)`
+  margin-left: 10px;
+`;
 
 const Symbol = styled.div`
   width: 20px;

--- a/src/pages/todo/TodoItem.tsx
+++ b/src/pages/todo/TodoItem.tsx
@@ -123,20 +123,6 @@ const TodoItem: React.FC<TodoItemProps> = ({
             </StatusDiv>
           )}
         </TopDiv>
-        <DueDateRangeDiv>
-          <DateRangeText dueDateRange={data.dueDateRange} />
-          {rangePickerOpen ? (
-            <CancelBtn
-              src={CANCEL_ICON}
-              onClick={handleRangePickerVisibleToggle}
-            />
-          ) : (
-            <DueDateRangeEditBtn
-              src={CALENDAR_ICON}
-              onClick={handleRangePickerVisibleToggle}
-            />
-          )}
-        </DueDateRangeDiv>
       </TodoItemInfoDiv>
       <TodoItemInfoDiv>
         <TaskName>
@@ -164,6 +150,22 @@ const TodoItem: React.FC<TodoItemProps> = ({
           )}
           <TrashBtn src={TRASH_ICON} onClick={() => handleDelete(data.id)} />
         </TaskControlDiv>
+      </TodoItemInfoDiv>
+      <TodoItemInfoDiv>
+        <DueDateRangeDiv>
+          {rangePickerOpen ? (
+            <CancelBtn
+              src={CANCEL_ICON}
+              onClick={handleRangePickerVisibleToggle}
+            />
+          ) : (
+            <DueDateRangeEditBtn
+              src={CALENDAR_ICON}
+              onClick={handleRangePickerVisibleToggle}
+            />
+          )}
+          <DateRangeText dueDateRange={data.dueDateRange} />
+        </DueDateRangeDiv>
       </TodoItemInfoDiv>
       {rangePickerOpen && (
         <CustomDatePicker
@@ -198,7 +200,7 @@ const TodoItemInfoDiv = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin: 28px 0;
+  margin: 12px 0;
   &:first-child {
     margin-top: 0;
   }
@@ -213,13 +215,13 @@ const TopDiv = styled.div`
 
 const DueDateRangeDiv = styled.div`
   display: flex;
-  flex-direction: row;
-  font-size: 11px;
   align-items: center;
+  font-size: 11px;
 `;
 
 const TaskName = styled.div`
   flex: 1;
+  margin-left: 10px;
 `;
 
 const TaskNameParagraph = styled.p`
@@ -241,10 +243,12 @@ const TrashBtn = styled(Button)``;
 const ConfirmBtn = styled(Button)``;
 const TaskNameEditBtn = styled(Button)``;
 const CancelBtn = styled(Button)`
-  margin-left: 10px;
+  margin: 0;
+  height: 12px;
 `;
 const DueDateRangeEditBtn = styled(Button)`
-  margin-left: 10px;
+  margin: 0;
+  height: 12px;
 `;
 
 const Symbol = styled.div`
@@ -267,6 +271,9 @@ const StatusDiv = styled.div`
   justify-content: center;
   align-items: center;
   cursor: pointer;
+  & > span {
+    white-space: pre;
+  }
 `;
 
 const CustomDatePicker = styled(DatePicker)`

--- a/src/pages/todo/TodoItem.tsx
+++ b/src/pages/todo/TodoItem.tsx
@@ -185,7 +185,6 @@ const TodoItemDiv = styled.div<{ isComplete: boolean }>`
   padding: 20px;
   background-color: #ffffff;
   border-radius: 10px;
-  margin: 20px;
   ${({ isComplete }) =>
     isComplete &&
     `

--- a/src/pages/todo/TodoList.tsx
+++ b/src/pages/todo/TodoList.tsx
@@ -5,11 +5,6 @@ import React from 'react';
 import { DragProvider } from 'store/drag';
 import TodoItem from './TodoItem';
 
-const TodoItemDiv = styled.div`
-  width: 100%;
-  padding: 10px;
-`;
-
 interface TodoItemProps {
   todoItems: Itodo[];
   handleTodoItems: (newTodoItems: Itodo[]) => void;
@@ -69,3 +64,16 @@ const TodoList: React.FC<TodoItemProps> = ({
 };
 
 export default TodoList;
+
+const TodoItemDiv = styled.div`
+  width: 100%;
+  & > div {
+    margin: 20px 0;
+  }
+  & > div:first-child {
+    margin-top: 0;
+  }
+  & > div:last-child {
+    margin-bottom: 0;
+  }
+`;


### PR DESCRIPTION
## Summary

- 투두 컴포넌트 디자인 변경

## What I did

- 투두 아이템의 margin과 padding을 줄여 한 페이지에 더 많은 아이템이 보이도록 함
- 투두 아이템 내 버튼 위치 변경
- 투두 헤더의 폼을 한 줄에 표현해 높이를 줄이고 모바일 화면 사이즈일 경우에만 여러 줄로 나타냄

- PC 사이즈
![image](https://user-images.githubusercontent.com/37607373/136641589-4ec53d42-838d-4cb3-a992-a57095f5bf0d.png)

- 모바일 사이즈
![image](https://user-images.githubusercontent.com/37607373/136641623-a43234b9-554a-48ed-9463-78439eee0aa8.png)

